### PR TITLE
Add Userjobs join table to handle 'likes' and relevant field for jobs

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,5 +1,7 @@
 class Job < ActiveRecord::Base
   belongs_to :company
+  has_many :userjobs
+  has_many :users, through: :userjobs
 
   validates :position, :description, :source, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ActiveRecord::Base
+  has_many :userjobs
+  has_many :jobs, through: :userjobs
+
   def self.find_or_create_from_auth(auth)
     user = User.find_or_create_by(uid: auth.uid)
     user.email = auth.info.email

--- a/app/models/userjob.rb
+++ b/app/models/userjob.rb
@@ -1,0 +1,4 @@
+class Userjob < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :job
+end

--- a/db/migrate/20150422234036_add_relevant_to_jobs.rb
+++ b/db/migrate/20150422234036_add_relevant_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddRelevantToJobs < ActiveRecord::Migration
+  def change
+    add_column :jobs, :relevant, :boolean, default: false
+  end
+end

--- a/db/migrate/20150422234627_create_userjobs.rb
+++ b/db/migrate/20150422234627_create_userjobs.rb
@@ -1,0 +1,10 @@
+class CreateUserjobs < ActiveRecord::Migration
+  def change
+    create_table :userjobs do |t|
+      t.references :user, index: true, foreign_key: true
+      t.references :job, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150422195050) do
+ActiveRecord::Schema.define(version: 20150422234627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,9 +40,10 @@ ActiveRecord::Schema.define(version: 20150422195050) do
     t.text     "description"
     t.string   "location"
     t.integer  "company_id"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
     t.string   "source"
+    t.boolean  "relevant",     default: false
   end
 
   create_table "jobtags", force: :cascade do |t|
@@ -61,6 +62,16 @@ ActiveRecord::Schema.define(version: 20150422195050) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "userjobs", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "job_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "userjobs", ["job_id"], name: "index_userjobs_on_job_id", using: :btree
+  add_index "userjobs", ["user_id"], name: "index_userjobs_on_user_id", using: :btree
+
   create_table "users", force: :cascade do |t|
     t.string   "username"
     t.string   "email"
@@ -75,4 +86,6 @@ ActiveRecord::Schema.define(version: 20150422195050) do
   add_foreign_key "hiddenjobs", "users"
   add_foreign_key "jobtags", "jobs"
   add_foreign_key "jobtags", "tags"
+  add_foreign_key "userjobs", "jobs"
+  add_foreign_key "userjobs", "users"
 end


### PR DESCRIPTION
This should reflect the changes discussed this afternoon:
- Have a join table (Userjobs) which stores "liked" jobs for each user.
- Each job then has many users ("likes").
- Add relevant (boolean) field to Jobs table, with default of false.
