### PR TITLE
Add likedJobs table and relevant field on Jobs table

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,5 +1,7 @@
 class Job < ActiveRecord::Base
   belongs_to :company
+  has_many :userjobs
+  has_many :users, through: :userjobs
 
   validates :position, :description, :source, presence: true
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,7 +1,7 @@
 class Job < ActiveRecord::Base
   belongs_to :company
-  has_many :userjobs
-  has_many :users, through: :userjobs
+  has_many :likedjobs
+  has_many :users, through: :likedjobs
 
   validates :position, :description, :source, presence: true
 

--- a/app/models/likedjob.rb
+++ b/app/models/likedjob.rb
@@ -1,4 +1,4 @@
-class Userjob < ActiveRecord::Base
+class Likedjob < ActiveRecord::Base
   belongs_to :user
   belongs_to :job
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ActiveRecord::Base
   has_many :userjobs
   has_many :jobs, through: :userjobs
 
+  validates :email, :username, presence: true
+
   def self.find_or_create_from_auth(auth)
     user = User.find_or_create_by(uid: auth.uid)
     user.email = auth.info.email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ActiveRecord::Base
   has_many :likedjobs
-  has_many :jobs, through: :likedjobs
+  has_many :jobsliked, through: :likedjobs, source: :job
+  has_many :hiddenjobs
+  has_many :jobshidden, through: :hiddenjobs, source: :job
 
   validates :email, :username, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ActiveRecord::Base
+  has_many :userjobs
+  has_many :jobs, through: :userjobs
+
   def self.find_or_create_from_auth(auth)
     user = User.find_or_create_by(uid: auth.uid)
     user.email = auth.info.email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ActiveRecord::Base
-  has_many :userjobs
-  has_many :jobs, through: :userjobs
+  has_many :likedjobs
+  has_many :jobs, through: :likedjobs
 
   validates :email, :username, presence: true
 

--- a/app/models/userjob.rb
+++ b/app/models/userjob.rb
@@ -1,0 +1,4 @@
+class Userjob < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :job
+end

--- a/db/migrate/20150422234036_add_relevant_to_jobs.rb
+++ b/db/migrate/20150422234036_add_relevant_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddRelevantToJobs < ActiveRecord::Migration
+  def change
+    add_column :jobs, :relevant, :boolean, default: false
+  end
+end

--- a/db/migrate/20150422234627_create_userjobs.rb
+++ b/db/migrate/20150422234627_create_userjobs.rb
@@ -1,0 +1,10 @@
+class CreateUserjobs < ActiveRecord::Migration
+  def change
+    create_table :userjobs do |t|
+      t.references :user, index: true, foreign_key: true
+      t.references :job, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150423144958_rename_userjobs_to_liked_jobs.rb
+++ b/db/migrate/20150423144958_rename_userjobs_to_liked_jobs.rb
@@ -1,0 +1,5 @@
+class RenameUserjobsToLikedJobs < ActiveRecord::Migration
+  def change
+    rename_table :userjobs, :likedjobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150422234627) do
+ActiveRecord::Schema.define(version: 20150423144958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,21 +56,21 @@ ActiveRecord::Schema.define(version: 20150422234627) do
   add_index "jobtags", ["job_id"], name: "index_jobtags_on_job_id", using: :btree
   add_index "jobtags", ["tag_id"], name: "index_jobtags_on_tag_id", using: :btree
 
-  create_table "tags", force: :cascade do |t|
-    t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "userjobs", force: :cascade do |t|
+  create_table "likedjobs", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "job_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  add_index "userjobs", ["job_id"], name: "index_userjobs_on_job_id", using: :btree
-  add_index "userjobs", ["user_id"], name: "index_userjobs_on_user_id", using: :btree
+  add_index "likedjobs", ["job_id"], name: "index_likedjobs_on_job_id", using: :btree
+  add_index "likedjobs", ["user_id"], name: "index_likedjobs_on_user_id", using: :btree
+
+  create_table "tags", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "username"
@@ -86,6 +86,6 @@ ActiveRecord::Schema.define(version: 20150422234627) do
   add_foreign_key "hiddenjobs", "users"
   add_foreign_key "jobtags", "jobs"
   add_foreign_key "jobtags", "tags"
-  add_foreign_key "userjobs", "jobs"
-  add_foreign_key "userjobs", "users"
+  add_foreign_key "likedjobs", "jobs"
+  add_foreign_key "likedjobs", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150422195050) do
+ActiveRecord::Schema.define(version: 20150422234627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,9 +40,10 @@ ActiveRecord::Schema.define(version: 20150422195050) do
     t.text     "description"
     t.string   "location"
     t.integer  "company_id"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
     t.string   "source"
+    t.boolean  "relevant",     default: false
   end
 
   create_table "jobtags", force: :cascade do |t|
@@ -61,6 +62,16 @@ ActiveRecord::Schema.define(version: 20150422195050) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "userjobs", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "job_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "userjobs", ["job_id"], name: "index_userjobs_on_job_id", using: :btree
+  add_index "userjobs", ["user_id"], name: "index_userjobs_on_user_id", using: :btree
+
   create_table "users", force: :cascade do |t|
     t.string   "username"
     t.string   "email"
@@ -75,4 +86,6 @@ ActiveRecord::Schema.define(version: 20150422195050) do
   add_foreign_key "hiddenjobs", "users"
   add_foreign_key "jobtags", "jobs"
   add_foreign_key "jobtags", "tags"
+  add_foreign_key "userjobs", "jobs"
+  add_foreign_key "userjobs", "users"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,4 +15,12 @@ FactoryGirl.define do
     location "Denver, CO"
     url "http://phprules.com"
   end
+
+  factory :user do
+    uid "12345"
+    username "turingstudent"
+    email "turingstudent@turing.io"
+    profile_image_url "nowhere@example.com"
+    token "faketoken"
+  end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -25,8 +25,15 @@ RSpec.describe Job, type: :model do
     expect(job.company.name).to eq("PHP Worldwide")
   end
 
+  it "is not relevant by default" do
+    job = create(:job)
+
+    expect(job.relevant).to be_falsey
+  end
+
   describe "validations" do
     it { should belong_to(:company) }
+    it { should have_many(:users) }
     it { should validate_presence_of(:position) }
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:source) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe User, type: :model do
   end
 
   describe "validations" do
-    it { should have_many(:jobs) }
+    it { should have_many(:jobsliked) }
+    it { should have_many(:jobshidden) }
     it { should validate_presence_of(:email) }
     it { should validate_presence_of(:username) }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,36 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "attributes" do
+    it "has a uid" do
+      user = create(:user)
+
+      expect(user.uid).to eq("12345")
+    end
+
+    it "has a username" do
+      user = create(:user)
+
+      expect(user.username.class).to eq(String)
+      expect(user.username).to eq("turingstudent")
+    end
+
+    it "has an email" do
+      user = create(:user)
+
+      expect(user.email).to eq("turingstudent@turing.io")
+    end
+
+    it "has a profile image" do
+      user = create(:user)
+
+      expect(user.profile_image_url).to eq("nowhere@example.com")
+    end
+  end
+
+  describe "validations" do
+    it { should have_many(:jobs) }
+    it { should validate_presence_of(:email) }
+    it { should validate_presence_of(:username) }
+  end
 end


### PR DESCRIPTION
This should reflect the changes discussed yesterday afternoon:
- Have a join table (Likedjobs) which stores "liked" jobs for each user.
- Each job then has many users ("likes").
- Add relevant (boolean) field to Jobs table, with default of false.
