### PR TITLE
Add company generation to API endpoint for creating jobs

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -3,9 +3,12 @@ class Api::V1::JobsController < ApplicationController
 
   def create
     job = Job.where(job_params).first_or_initialize
+
     if !job.new_record?
       render json: job, status: :found
     elsif job.new_record? && job.save
+      company = find_or_create_company
+      company.jobs << job
       render json: job, status: :created
     else
       render json: job.errors.full_messages, status: :unprocessable_entity
@@ -29,5 +32,10 @@ class Api::V1::JobsController < ApplicationController
   def job_params
     params.require(:job).permit(:position, :description, :posting_date,
                                 :source, :location)
+  end
+
+  def find_or_create_company
+    company = params[:job]["company"] || "unknowncompany"
+    Company.find_or_create_by(name: company)
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -21,19 +21,10 @@ class Company < ActiveRecord::Base
         compensationandbenefits_rating: result["compensationAndBenefitsRating"].to_f,
         careeropportunities_rating: result["careerOpportunitiesRating"].to_f,
         worklifebalance_rating: result["workLifeBalanceRating"].to_f,
-        recommendtofriends_rating: result["recommendToFriendRating"].to_f
-        )
-    end
-
-    if result && result["ceo"]
-      update_attributes(
+        recommendtofriends_rating: result["recommendToFriendRating"].to_f,
         ceo_name: result["ceo"]["name"],
         approval_rating: result["ceo"]["pctApprove"].to_i
         )
-    end
-
-    if result && result["ceo"] && result["ceo"]["image"]
-      update_attributes(ceo_picture: result["ceo"]["image"]["src"])
     end
   end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -21,11 +21,19 @@ class Company < ActiveRecord::Base
         compensationandbenefits_rating: result["compensationAndBenefitsRating"].to_f,
         careeropportunities_rating: result["careerOpportunitiesRating"].to_f,
         worklifebalance_rating: result["workLifeBalanceRating"].to_f,
-        recommendtofriends_rating: result["recommendToFriendRating"].to_f,
+        recommendtofriends_rating: result["recommendToFriendRating"].to_f
+        )
+    end
+
+    if result && result["ceo"]
+      update_attributes(
         ceo_name: result["ceo"]["name"],
-        ceo_picture: result["ceo"]["image"]["src"],
         approval_rating: result["ceo"]["pctApprove"].to_i
-      )
+        )
+    end
+
+    if result && result["ceo"] && result["ceo"]["image"]
+      update_attributes(ceo_picture: result["ceo"]["image"]["src"])
     end
   end
 end

--- a/spec/controllers/api/v1/companies_controller_spec.rb
+++ b/spec/controllers/api/v1/companies_controller_spec.rb
@@ -15,11 +15,9 @@ RSpec.describe Api::V1::CompaniesController, type: :controller do
   end
 
   describe "#GET index" do
-    before(:all) do
-      3.times { create(:company) }
-    end
-
     it "#GET api/v1/companies" do
+      3.times { create(:company) }
+
       get :index
       result = JSON.parse(response.body)["companies"]
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,7 +8,7 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   config.infer_spec_type_from_file_location!
 end


### PR DESCRIPTION
This will find or create a company and associate it with each job posted to the API endpoint.
The company name must be provided in the job hash. For example,
 job = {
        position: "PHP Dev2",
        description: "Only the best...",
        source: "http://www.the-internet.com",
        location: "London, UK",
        company: "My company"
      }
If a company name is not provided, a default company with the name "unknowncompany" is found or created.
