### PR TITLE
update tag length limit

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,5 +2,5 @@ class Tag < ActiveRecord::Base
   has_many :jobtags
   has_many :jobs, through: :jobtags
 
-  validates :name, presence: true, length: { maximum: 20 }, uniqueness: true
+  validates :name, presence: true, length: { maximum: 30 }, uniqueness: true
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Tag, type: :model do
   describe "validations" do
     it { should validate_presence_of(:name) }
-    it { should validate_length_of(:name).is_at_most(20) }
+    it { should validate_length_of(:name).is_at_most(30) }
     it { should validate_uniqueness_of(:name) }
     it { should have_many(:jobs) }
   end


### PR DESCRIPTION
Some of the predefined tags on stack overflow were longer than 20 chars, updated to 30. 
